### PR TITLE
Update RibbonFactory.cs

### DIFF
--- a/src/VSTOContrib.Core/RibbonFactory/RibbonFactory.cs
+++ b/src/VSTOContrib.Core/RibbonFactory/RibbonFactory.cs
@@ -236,7 +236,10 @@ namespace VSTOContrib.Core.RibbonFactory
         /// <returns></returns>
         public bool GetVisible(IRibbonControl control)
         {
-            return (bool)ribbonFactoryController.InvokeGet(control, () => GetVisible(null));
+            if (control == null || control.Context == null) return false;
+
+            object result = ribbonFactoryController.InvokeGet(control, () => GetVisible(null));
+            return (bool) result;
         }
 
         /// <summary>
@@ -370,7 +373,10 @@ namespace VSTOContrib.Core.RibbonFactory
         /// <returns></returns>
         public bool GetPressed(IRibbonControl control)
         {
-            return (bool)ribbonFactoryController.InvokeGet(control, () => GetPressed(null));
+            if (control == null || control.Context == null) return false;
+
+            object result = ribbonFactoryController.InvokeGet(control, () => GetPressed(null));
+            return (bool) result;
         }
 
         /// <summary>


### PR DESCRIPTION
It appears that control can have an empty Context and causing GetVisible to crash hard ... 
I assume under the hood control.Context is used but I don't see where.
(Added also the return line to make it easier to get the return value)
The context check should probably be added to -all- control using methods but so far I just ran into issues on GetVisible and GetPressed. Have only changed GetVisible and GetPressed to get your feedback.
