### PR TITLE
Update RibbonFactoryController.cs

### DIFF
--- a/src/VSTOContrib.Core/RibbonFactory/RibbonFactoryController.cs
+++ b/src/VSTOContrib.Core/RibbonFactory/RibbonFactoryController.cs
@@ -164,12 +164,12 @@ namespace VSTOContrib.Core.RibbonFactory
             {
                 var innerEx = e.InnerException;
                 PreserveStackTrace(innerEx);
-                if (vstoContribContext.ErrorHandlers.Count == 0)
+                if (vstoContribContext.ErrorHandlers != null && vstoContribContext.ErrorHandlers.Count == 0)
                 {
                     Trace.TraceError(innerEx.ToString());
                 }
 
-                var handled = vstoContribContext.ErrorHandlers.Any(errorHandler => errorHandler.Handle(innerEx));
+                var handled = vstoContribContext.ErrorHandlers != null && vstoContribContext.ErrorHandlers.Any(errorHandler => errorHandler.Handle(innerEx));
 
                 if (!handled)
                     throw innerEx;


### PR DESCRIPTION
Ran into situation where vstoContribContext.ErrorHandlers was null, throwing another exception ... Added check for vstoContribContext.ErrorHandlers != null
